### PR TITLE
Bail if dedicated syncing is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # VIP Jetpack Sync Cron
+Note: As of Jetpack 11.2+, the dedicated sync option is available for usage instead. This plugin will bail early if Jetpack has dedicated sync enabled.
+
 By default, Jetpack Sync will sometimes attempt to piggyback on various cron or API requests - causing slowdowns on the shutdown hook. This plugin modifies that behaviour and ensures that Jetpack only syncs on the dedicated cron task.
 
 ## Installation

--- a/vip-jetpack-sync-cron.php
+++ b/vip-jetpack-sync-cron.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: VIP Jetpack Sync Cron
 Description: This plugin ensures that Jetpack only syncs on the dedicated cron task.
-Version: 2.0
+Version: 2.1
 Author: Rebecca Hum, Automattic
 */
 
@@ -19,10 +19,17 @@ class VIP_Jetpack_Sync_Cron {
 	 */
 	public static function init() {
 		if ( ! class_exists( 'Jetpack' ) ) { // Bail if no Jetpack.
+			__doing_it_wrong( __FUNCTION__, 'VIP_Jetpack_Sync_Cron::Jetpack plugin must be activated!', null );
+			return;
+		}
+
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '11.2', '>=' ) && Settings::is_dedicated_sync_enabled() ) { // Bail if dedicated syncing is enabled.
+			__doing_it_wrong( __FUNCTION__, 'VIP_Jetpack_Sync_Cron::Jetpack dedicated sync must be disabled!', null );
 			return;
 		}
 
 		if ( ! Actions::sync_via_cron_allowed() ) { // Bail if no syncing via cron allowed.
+			__doing_it_wrong( __FUNCTION__, 'VIP_Jetpack_Sync_Cron::Jetpack syncing via cron must be enabled!', null );
 			return;
 		}
 


### PR DESCRIPTION
The Dedicated Sync option in Jetpack does what this plugin seeks to do. So let's add a note in the plugin README and bail if it's enabled.